### PR TITLE
changing default max container width to 100%, by default

### DIFF
--- a/_neutron.scss
+++ b/_neutron.scss
@@ -7,7 +7,7 @@
 
 // General Settings
 $neutron-column-padding: 4px 8px !default;
-$neutron-container-max-width: 960px !default;
+$neutron-container-max-width: 100% !default;
 $neutron-flush-margin: true !default;
 $neutron-flush-padding: false !default;
 


### PR DESCRIPTION
I think that is no reason to "lock" the container with 960px. This is making difficult for everybody that wants a full screen site.